### PR TITLE
BETSE 0.8.0 bumped.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "betse" %}
-{% set version = "0.7.0" %}
-{% set sha256 = "845896f4c30b3970d5bd9501e0ca754eef5af0d742de76103f66c8c8c58e4eca" %}
+{% set version = "0.8.0" %}
+{% set sha256 = "ef2ebe74c2b6ed7db110fe06258aa53c51846eada063a2ca28e2581cfdd66341" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
This commit bumps conda-forge hosting to the most recent stable release: **BETSE 0.8.0 (Kind Kaufmann).**

Kaufmann is a prominent bioelectrician. We venerate his time-honoured surname with a BETSE codename.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered](https://conda-forge.org/docs/conda_smithy.html#how-to-re-render) with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Because I am a simple man-child with a bushy neckbeard, I have no idea what "[re-rendering](https://conda-forge.org/docs/conda_smithy.html#how-to-re-render) with the latest `conda-smithy` means." Presumably, nothing good. So, I didn't do that.

Only time will tell whether I done right. Tacos for all! :taco: 