### PR TITLE
 BETSE 0.8.2 bumped.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "betse" %}
-{% set version = "0.8.1" %}
-{% set sha256 = "48de6b52c31110b4b005c5ecf62c96ae717c7bb6e7052416e10075bdb1befdff" %}
+{% set version = "0.8.2" %}
+{% set sha256 = "350818c9fe0e9284a1f3c2fabf380b38c0db8a2a1a1554608d1581ff3b59a19c" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
This commit bumps conda-forge hosting to the most recent stable release: BETSE 0.8.2 (Kindest Kaufmann).

It is exciting. The heart thrills. The head pounds. The migraine swells. Rejoice!

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
