### PR TITLE
BETSE 0.8.3 bumped.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "betse" %}
-{% set version = "0.8.2" %}
-{% set sha256 = "350818c9fe0e9284a1f3c2fabf380b38c0db8a2a1a1554608d1581ff3b59a19c" %}
+{% set version = "0.8.3" %}
+{% set sha256 = "ee54a40b83ee611a23b18796a7c615a77b8f0dea720dfc22b32dd9fd46419b30" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
This commit bumps conda-forge hosting to the most recent stable release: BETSE 0.8.3 (Kindly Kaufmann).

Significant changes including restoring dill >= 0.2.8 compatibility by locally resolving uqfoundation/dill#268. *Grrrrr!*

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
