### PR TITLE
BETSE 0.8.4 bumped.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "betse" %}
-{% set version = "0.8.3" %}
-{% set sha256 = "ee54a40b83ee611a23b18796a7c615a77b8f0dea720dfc22b32dd9fd46419b30" %}
+{% set version = "0.8.4" %}
+{% set sha256 = "369ee88644e86a32bb0e233e4476cb2ea08b5f6e9e5875caf36273fd7e9c21b4" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
This commit bumps conda-forge hosting to the most recent stable release: BETSE 0.8.4 (Kindlier Kaufmann).

Significant changes include:
    
* Default time step for the cutting event reverted to 0.0 s (i.e., the initial time step). While this and prior releases technically permit the cutting event to occur at subsequent time steps, doing so currently results in fatal exceptions during the `betse plot sim` phase and hence is highly discouraged. This issue will be permanently resolved in the next stable release of BETSE - to be released shortly.

May this be the last stable release for this month. Or at least this week. O.K., I'd settle for merely today. `</mournful_sigh>`

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
