### PR TITLE
BETSE 0.9.0 bumped.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "betse" %}
-{% set version = "0.8.4" %}
-{% set sha256 = "369ee88644e86a32bb0e233e4476cb2ea08b5f6e9e5875caf36273fd7e9c21b4" %}
+{% set version = "0.9.0" %}
+{% set sha256 = "9a1b9e0557c66e234b9843b9047b9ae4a913f64edc082b979d2193a8c4c64eee" %}
 
 package:
   name: {{ name|lower }}
@@ -21,10 +21,10 @@ build:
 requirements:
   build:
     - pip
-    - python >=3.4
+    - python >=3.5
     - setuptools >=3.3
   run:
-    - python >=3.4
+    - python >=3.5
     - setuptools >=3.3
     - dill >=0.2.3
     - graphviz >=2.38.0


### PR DESCRIPTION
This commit bumps conda-forge hosting to the most recent stable release: **BETSE 0.9.0 (Lucky Levin).**

For those following along at home,<sup>*hi!*</sup> the largely uninteresting official changelog is as follows:

* Python >= 3.5 required. In accordance with the looming end-of-life
  (EOL) of Python 3.4, BETSE now strictly requires at least Python 3.5.
* Single-cell plots added. The following two single-cell plots may now
  be added to both the initialization  and simulation export pipelines:
  * "ion_calcium_er", plotting all calcium (i.e., Ca2+) ion
    concentrations for the endoplasmic reticulum of the single cell
    indexed by the current simulation configuration over all sampled
    time steps.
  * "voltage_membrane_er", plotting all transmembrane voltages across
    the endoplasmic reticulum of the single cell indexed by the current
    simulation configuration over all sampled time steps.
* Deprecation warnings resolved. Deprecation warnings emitted by
  py.test >= 3.1.0, Python >= 3.6, and recent versions of Numpy have
  been summarily squelched.
* Simulation callbacks substantially improved, improving UX
  responsiveness in downstream consumers (e.g., BETSEE). Specifically:
  * Seed progress granularized. Progress for the seed phase is now
    reported in a more granular (i.e., fine-grained) manner.
  * Export progress. Progress on exporting CSV files, plots, and
    animations from both the initialization export (i.e., "betse plot
    init") and simulation export (i.e., "betse plot sim") phases is now
    reported in a highly granular manner.
  * Callbacks API generalized. Specifically, in the
    "betse.util.type.call.callbacks" submodule:
    * The new CallbacksBC.progress_stated() callback enables source
      callables to notify sink callbacks of arbitrary human-readable
      strings informing end users of the current state of progress. As
      semantic sugar, the existing CallbacksBC.progressed_next()
      callback has been augmented to accept the same strings.
    * The new CallbacksABC.progressed_last() callback enables source
      callables to safely iterate progress, improving robustness and
      maintainability.
* Simulation variables streamlined. Specifically:
  * All core simulation pathname variables now reside in the central
    "Parameters" class rather than distributed across both that and the
    "Cells" and "Simulator" classes, reducing logic across the codebase.
  * The obsolete "Parameters.total_time_accelerated" variable has been
    removed.
  * All but one reference to the obsolete "Parameters._run_sim" boolean
    have been removed in lieu of the "SimPhase.kind" enumeration.
  * The obsolete Parameters.set_time_profile() method has been
    refactored into the SimPhase._init_kludge_time() method.
  * The "Parameters.init_tsteps" and "Parameters.sim_tsteps" variables
    are now unconditionally defined rather than only conditionally
    defined when the SimPhase._init_kludge_time() method is called.
* Matplotlib API sanitized. The antiquated
  "betse.lib.matplotlib.matplotlibs" submodule now complies with the
  modern Matplotlib API in a robust manner. Specifically:
  * Headless Qt blacklisted. The default "Qt5Agg" backend is now
    blacklisted when the current process is headless, preventing
    Matplotlib from silently terminating this process.
  * Visualization API improved. The "betse.science.visual.visabc"
    submodule has been improved to preferentially leverage the
    object-oriented Matplotlib API over the procedural "pyplot" API
    where feasible, reducing unexpected exceptions from backends.
* Installation sanitized. Specifically:
  * The top-level "MANIFEST.in" file now explicitly includes and
    excludes all installation-time paths as appropriate.
  * The top-level "setup.py" script now conforms to the more succinct
    and hence saner approach of downstream consumers (e.g., BETSEE).
* Descriptor API added. The new "betse.util.type.descriptor.descs"
  submodule defines general-purpose descriptors, including the
  @classproperty_readonly and @abstractclassproperty_readonly decorators
  implementing concrete and abstract read-only class properties
  respectively.
* Iterable subpackage added. The new "betse.util.type.iterable"
  subpackage now aggregates all subpackages pertaining to container
  datatypes (e.g., iterables, queues, sequences). Specifically:
  * Queue API added. The new "betse.util.type.iterable.queues" submodule
    now aggregates queue-centric functionality, including the efficient
    popping of multiple items from the head of a queue.
  * Tuple API added. The new "betse.util.type.iterable.tuples" submodule
    now aggregates tuple-centric functionality, including the efficient
    creation of named tuple subclasses.
* CLI API generalized. The
  "betse.util.cli.clicmdabc.CLISubcommandableABC" abstract base class
  now helpfully provides a sane implementation of the abstract
  _help_epilog() property, simplifying subclass implementation.
* Class decorator API generalized. The new
  @betse.util.type.decorator.abstractclassmethod decorator trivially
  enables definition of abstract class methods.
* Enumeration API generalized. The new
  betse.util.type.enums.get_member_from_value() function expands the
  functionality provided by the existing
  betse.util.type.enums.get_member_from_name() function to enumeration
  member values.
* Objects API generalized. The "betse.util.type.obj.objects" submodule
  has been improved to:
  * Enable callers to pass both classes and tuples of classes to
    relevant submodule functions (e.g., die_if_instance()).
  * Provide additional general-purpose getters for dynamically
    retrieving arbitrary object attributes.
* Threading API generalized. The "betse.util.py.pythread" submodule now
  provides quasi-portable functionality for validating whether the
  active Python interpreter leverages a Global Interpreter Lock (GIL).
* Weak reference API generalized. The betse.util.py.pyref.refer_weak()
  function now transparently creates weak references to bound methods,
  which require special handling to avoid subtle race conditions.
* Module API shifted. The prior "betse.util.type.modules" submodule has
  now been renamed to "betse.util.py.pymodule" for orthogonality.
* Continuous integration (CI) test suite improved. Specifically:
  * Default simulation test expanded. The "betse_cli_sim_default"
    functional test now exercise all simulation subcommands (i.e., seed,
    initialization, and simulation) rather than merely the seed and
    initialization subcommands, reducing the likelihood of edge-case
    computational instabilities.
* Reference documentation improved. Specifically:
  * Project badges (i.e., flat images synopsizing project health) have
    been externalized from our front-facing "README.rst" document into
    corresponding GitLab-aware project settings, improving both badge
    visibility and aesthetics.
  * The betse.util.py.pyref.proxy_weak() function docstring has been
    significantly revised in accordance with the actual behaviour of the
    underlying weakref.proxy() function.