### PR TITLE
BETSE 0.9.1 bumped.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1000
+  number: 0
   entry_points:
     - betse = betse.__main__:main
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,11 +21,11 @@ build:
 requirements:
   host:
     - python >=3.5
-    - setuptools >=3.3
+    - setuptools
     - pip
   run:
     - python >=3.5
-    - setuptools >=3.3
+    - setuptools
     - dill >=0.2.3
     - graphviz >=2.38.0
     - matplotlib >=1.5.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "betse" %}
-{% set version = "0.9.0" %}
-{% set sha256 = "9a1b9e0557c66e234b9843b9047b9ae4a913f64edc082b979d2193a8c4c64eee" %}
+{% set version = "0.9.1" %}
+{% set sha256 = "352de77e95ca5f2df1683fd1218b7c6ae3fe0b019b6274d61da86637782b774a" %}
 
 package:
   name: {{ name|lower }}
@@ -15,14 +15,14 @@ build:
   number: 0
   entry_points:
     - betse = betse.__main__:main
-  script: python -m pip install --no-deps --ignore-installed .
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
   noarch: python
 
 requirements:
-  build:
-    - pip
+  host:
     - python >=3.5
     - setuptools >=3.3
+    - pip
   run:
     - python >=3.5
     - setuptools >=3.3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,11 +21,11 @@ build:
 requirements:
   host:
     - python >=3.5
-    - setuptools
+    - setuptools >=3.3
     - pip
   run:
     - python >=3.5
-    - setuptools
+    - setuptools >=3.3
     - dill >=0.2.3
     - graphviz >=2.38.0
     - matplotlib >=1.5.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ build:
   number: 0
   entry_points:
     - betse = betse.__main__:main
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+  script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv"
   noarch: python
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1000
   entry_points:
     - betse = betse.__main__:main
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"


### PR DESCRIPTION
This pull request bumps conda-forge hosting to this project's most recent stable release: **BETSE 0.9.1** (*Luckier Levin*).

## Dear Nordic Gods Above, Why Is This Happening!

This pull request is happening because [cf-regro-autotick-bot](https://github.com/regro/cf-scripts), despite its infinite wisdom, [failed to automatically do so](https://github.com/conda-forge/betse-feedstock/pull/9). Specifically, Circle-CI tests [vomited up an obscure non-human-readable `conda` exception](https://circleci.com/gh/conda-forge/betse-feedstock/19?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link):

```
...
+ make_build_number /home/conda/feedstock_root /home/conda/recipe_root /home/conda/feedstock_root/.ci_support/linux_.yaml
No numpy version specified in conda_build_config.yaml.  Falling back to default numpy value of 1.11
Adding in variants from internal_defaults
Adding in variants from argument_variants
Attempting to finalize metadata for betse
Solving environment: ...working... done
> conda-forge:: No build number clobber gererated!
Traceback (most recent call last):
  File "/opt/conda/lib/python3.6/site-packages/conda_forge_ci_setup/build_utils.py", line 136, in make_build_number
    "Only legacy compilers only valid with build numbers < 1000"
ValueError: Only legacy compilers only valid with build numbers < 1000
+ conda build /home/conda/recipe_root -m /home/conda/feedstock_root/.ci_support/linux_.yaml --clobber-file /home/conda/feedstock_root/.ci_support/clobber_linux_.yaml --quiet
BUILD START: ['betse-0.9.1-py_0.tar.bz2']
export PREFIX=/home/conda/feedstock_root/build_artifacts/betse_1544253421123/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_place
export SRC_DIR=/home/conda/feedstock_root/build_artifacts/betse_1544253421123/work
Processing $SRC_DIR
  Installing build dependencies: started
  Installing build dependencies: finished with status 'error'
  Complete output from command $PREFIX/bin/python -m pip install --ignore-installed --no-user --prefix /tmp/pip-build-env-njinqvm9 --no-warn-script-location --no-binary :none: --only-binary :none: --no-index -- setuptools wheel:
  Collecting setuptools
    Could not find a version that satisfies the requirement setuptools (from versions: )
  No matching distribution found for setuptools
  
  ----------------------------------------
Command "/home/conda/feedstock_root/build_artifacts/betse_1544253421123/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_place/bin/python -m pip install --ignore-installed --no-user --prefix /tmp/pip-build-env-njinqvm9 --no-warn-script-location --no-binary :none: --only-binary :none: --no-index -- setuptools wheel" failed with error code 1 in None
Traceback (most recent call last):
  File "/opt/conda/bin/conda-build", line 11, in <module>
    sys.exit(main())
  File "/opt/conda/lib/python3.6/site-packages/conda_build/cli/main_build.py", line 456, in main
    execute(sys.argv[1:])
  File "/opt/conda/lib/python3.6/site-packages/conda_build/cli/main_build.py", line 447, in execute
    verify=args.verify, variants=args.variants)
  File "/opt/conda/lib/python3.6/site-packages/conda_build/api.py", line 208, in build
    notest=notest, need_source_download=need_source_download, variants=variants)
  File "/opt/conda/lib/python3.6/site-packages/conda_build/build.py", line 2311, in build_tree
    notest=notest,
  File "/opt/conda/lib/python3.6/site-packages/conda_build/build.py", line 1477, in build
    cwd=src_dir, stats=build_stats)
  File "/opt/conda/lib/python3.6/site-packages/conda_build/utils.py", line 374, in check_call_env
    return _func_defaulting_env_to_os_environ('call', *popenargs, **kwargs)
  File "/opt/conda/lib/python3.6/site-packages/conda_build/utils.py", line 354, in _func_defaulting_env_to_os_environ
    raise subprocess.CalledProcessError(proc.returncode, _args)
subprocess.CalledProcessError: Command '['/bin/bash', '-e', '/home/conda/feedstock_root/build_artifacts/betse_1544253421123/work/conda_build.sh']' returned non-zero exit status 1.
Exited with code 1
```

When bumping fails with an egregious spelling mistake (i.e., **"gererated"** – I do *not* believe that is a word), you just know we're in uncharted territory.

## Irrelevant Minutiae that May Actually be Relevant

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
