### PR TITLE
Mandatory dependencies bumped.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - betse = betse.__main__:main
   script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv"
@@ -30,7 +30,7 @@ requirements:
     - graphviz >=2.38.0
     - matplotlib >=1.5.0
     - networkx >=2.0
-    - numpy >=1.8.2
+    - numpy >=1.13.0
     - pillow >=2.3.0
     - pydot >=1.0.28
     - pyyaml >=3.10


### PR DESCRIPTION
BETSE 1.0.0 now explicitly requires numpy >= 1.13.0. Previously, this BETSE release was erroneously noted to require only numpy >= 1.8.2.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
